### PR TITLE
Use MessagePack bin type

### DIFF
--- a/python/datagrammessages/connection_handler.py
+++ b/python/datagrammessages/connection_handler.py
@@ -2,7 +2,7 @@ import msgpack
 import threading
 
 
-def encode(name, arg, msgpack_opt={'use_single_float': True}):
+def encode(name, arg, msgpack_opt={'use_single_float': True, 'use_bin_type': True}):
     """
     Encode a message datagram
     """


### PR DESCRIPTION
Per default python msgpack uses string type to encode a bytes object.
